### PR TITLE
Explain that modernizr.js was removed in Changelog

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ Theme documentation is available on http://colorlib.com/wp/support/sparkling
 * Updated FontAwesome to v5.1.1
 * Updated FlexSlider to 2.7.0
 * Added Academicons ( https://jpswalsh.github.io/academicons/ )
+* Removed Modernizr.js from distribution
 * Full changelog can be seen here: https://github.com/puikinsh/Sparkling/milestone/1?closed=1
 
 # 2.3.4


### PR DESCRIPTION
I was scratching my head trying to find when modernizr.js was removed from Sparkling, and for what reason. All I found was [this commit](https://github.com/ColorlibHQ/Sparkling/commit/c8cbeae0ba3a9d7d5cddaee44fbd097eb7f1abc7#diff-78cd5aa3783a74555c9938a2a81d01c6L255) showing that it was indeed removed, but no explanation stating why.

I thought as a bare minimum this change should be included in the changelog, since for anybody upgrading Sparkling (like me) it's important to know - it's possible some of us are using modernizr.js in other parts of our side.

Thanks for maintaining this awesome plugin!