### PR TITLE
Social Icons: recognize dblp.org

### DIFF
--- a/style.css
+++ b/style.css
@@ -1844,6 +1844,10 @@ p.logged-in-as {
     background-color: #12539B !important;
 }
 
+#menu-social li a[href*="dblp.org"]:hover {
+    background-color: #12539B !important;
+}
+
 #menu-social li a[href*="depsy.org"]:hover {
     background-color: #2BB0E9 !important;
 }
@@ -2218,6 +2222,11 @@ p.logged-in-as {
 }
 
 #menu-social li a[href*="dblp.uni-trier.de"]:before {
+    font-family: 'Academicons';
+    content: "\e94f";
+}
+
+#menu-social li a[href*="dblp.org"]:before {
     font-family: 'Academicons';
     content: "\e94f";
 }


### PR DESCRIPTION
This pull requests adds the official domain of the DBLP project to the social icon list.

Originally, the project was initiated by the University of Trier, so dblp.uni-trier.de is still correct. However, the official domain is now dblp.org. For this reason, I would suggest to support both URLs for the DBLP social icon.

Best regards
Matthias