### PR TITLE
Refresh readme, consolidate changelog, ship GPLv2 licence text

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,622 +1,281 @@
                     GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+                       Version 2, June 1991
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
                             Preamble
 
-  The GNU General Public License is a free, copyleft license for
-software and other kinds of works.
-
-  The licenses for most software and other practical works are designed
-to take away your freedom to share and change the works.  By contrast,
-the GNU General Public License is intended to guarantee your freedom to
-share and change all versions of a program--to make sure it remains free
-software for all its users.  We, the Free Software Foundation, use the
-GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors.  You can apply it to
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
 your programs, too.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
-them if you wish), that you receive source code or can get it if you
-want it, that you can change the software or use pieces of it in new
-free programs, and that you know you can do these things.
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
 
-  To protect your rights, we need to prevent others from denying you
-these rights or asking you to surrender the rights.  Therefore, you have
-certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
 
   For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must pass on to the recipients the same
-freedoms that you received.  You must make sure that they, too, receive
-or can get the source code.  And you must show them these terms so they
-know their rights.
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
 
-  Developers that use the GNU GPL protect your rights with two steps:
-(1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
 
-  For the developers' and authors' protection, the GPL clearly explains
-that there is no warranty for this free software.  For both users' and
-authors' sake, the GPL requires that modified versions be marked as
-changed, so that their problems will not be attributed erroneously to
-authors of previous versions.
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
 
-  Some devices are designed to deny users access to install or run
-modified versions of the software inside them, although the manufacturer
-can do so.  This is fundamentally incompatible with the aim of
-protecting users' freedom to change the software.  The systematic
-pattern of such abuse occurs in the area of products for individuals to
-use, which is precisely where it is most unacceptable.  Therefore, we
-have designed this version of the GPL to prohibit the practice for those
-products.  If such problems arise substantially in other domains, we
-stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.
-
-  Finally, every program is threatened constantly by software patents.
-States should not allow patents to restrict development and use of
-software on general-purpose computers, but in those that do, we wish to
-avoid the special danger that patents applied to a free program could
-make it effectively proprietary.  To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
 
-                       TERMS AND CONDITIONS
-
-  0. Definitions.
-
-  "This License" refers to version 3 of the GNU General Public License.
-
-  "Copyright" also means copyright-like laws that apply to other kinds of
-works, such as semiconductor masks.
-
-  "The Program" refers to any copyrightable work licensed under this
-License.  Each licensee is addressed as "you".  "Licensees" and
-"recipients" may be individuals or organizations.
-
-  To "modify" a work means to copy from or adapt all or part of the work
-in a fashion requiring copyright permission, other than the making of an
-exact copy.  The resulting work is called a "modified version" of the
-earlier work or a work "based on" the earlier work.
-
-  A "covered work" means either the unmodified Program or a work based
-on the Program.
-
-  To "propagate" a work means to do anything with it that, without
-permission, would make you directly or secondarily liable for
-infringement under applicable copyright law, except executing it on a
-computer or modifying a private copy.  Propagation includes copying,
-distribution (with or without modification), making available to the
-public, and in some countries other activities as well.
-
-  To "convey" a work means any kind of propagation that enables other
-parties to make or receive copies.  Mere interaction with a user through
-a computer network, with no transfer of a copy, is not conveying.
-
-  An interactive user interface displays "Appropriate Legal Notices"
-to the extent that it includes a convenient and prominently visible
-feature that (1) displays an appropriate copyright notice, and (2)
-tells the user that there is no warranty for the work (except to the
-extent that warranties are provided), that licensees may convey the
-work under this License, and how to view a copy of this License.  If
-the interface presents a list of user commands or options, such as a
-menu, a prominent item in the list meets this criterion.
-
-  1. Source Code.
-
-  The "source code" for a work means the preferred form of the work
-for making modifications to it.  "Object code" means any non-source
-form of a work.
-
-  A "Standard Interface" means an interface that either is an official
-standard defined by a recognized standards body, or, in the case of
-interfaces specified for a particular programming language, one that
-is widely used among developers working in that language.
-
-  The "System Libraries" of an executable work include anything, other
-than the work as a whole, that (a) is included in the normal form of
-packaging a Major Component, but which is not part of that Major
-Component, and (b) serves only to enable use of the work with that
-Major Component, or to implement a Standard Interface for which an
-implementation is available to the public in source code form.  A
-"Major Component", in this context, means a major essential component
-(kernel, window system, and so on) of the specific operating system
-(if any) on which the executable work runs, or a compiler used to
-produce the work, or an object code interpreter used to run it.
-
-  The "Corresponding Source" for a work in object code form means all
-the source code needed to generate, install, and (for an executable
-work) run the object code and to modify the work, including scripts to
-control those activities.  However, it does not include the work's
-System Libraries, or general-purpose tools or generally available free
-programs which are used unmodified in performing those activities but
-which are not part of the work.  For example, Corresponding Source
-includes interface definition files associated with source files for
-the work, and the source code for shared libraries and dynamically
-linked subprograms that the work is specifically designed to require,
-such as by intimate data communication or control flow between those
-subprograms and other parts of the work.
-
-  The Corresponding Source need not include anything that users
-can regenerate automatically from other parts of the Corresponding
-Source.
-
-  The Corresponding Source for a work in source code form is that
-same work.
-
-  2. Basic Permissions.
-
-  All rights granted under this License are granted for the term of
-copyright on the Program, and are irrevocable provided the stated
-conditions are met.  This License explicitly affirms your unlimited
-permission to run the unmodified Program.  The output from running a
-covered work is covered by this License only if the output, given its
-content, constitutes a covered work.  This License acknowledges your
-rights of fair use or other equivalent, as provided by copyright law.
-
-  You may make, run and propagate covered works that you do not
-convey, without conditions so long as your license otherwise remains
-in force.  You may convey covered works to others for the sole purpose
-of having them make modifications exclusively for you, or provide you
-with facilities for running those works, provided that you comply with
-the terms of this License in conveying all material for which you do
-not control copyright.  Those thus making or running the covered works
-for you must do so exclusively on your behalf, under your direction
-and control, on terms that prohibit them from making any copies of
-your copyrighted material outside their relationship with you.
-
-  Conveying under any other circumstances is permitted solely under
-the conditions stated below.  Sublicensing is not allowed; section 10
-makes it unnecessary.
-
-  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
-
-  No covered work shall be deemed part of an effective technological
-measure under any applicable law fulfilling obligations under article
-11 of the WIPO copyright treaty adopted on 20 December 1996, or
-similar laws prohibiting or restricting circumvention of such
-measures.
-
-  When you convey a covered work, you waive any legal power to forbid
-circumvention of technological measures to the extent such circumvention
-is effected by exercising rights under this License with respect to
-the covered work, and you disclaim any intention to limit operation or
-modification of the work as a means of enforcing, against the work's
-users, your or third parties' legal rights to forbid circumvention of
-technological measures.
-
-  4. Conveying Verbatim Copies.
-
-  You may convey verbatim copies of the Program's source code as you
-receive it, in any medium, provided that you conspicuously and
-appropriately publish on each copy an appropriate copyright notice;
-keep intact all notices stating that this License and any
-non-permissive terms added in accord with section 7 apply to the code;
-keep intact all notices of the absence of any warranty; and give all
-recipients a copy of this License along with the Program.
-
-  You may charge any price or no price for each copy that you convey,
-and you may offer support or warranty protection for a fee.
-
-  5. Conveying Modified Source Versions.
-
-  You may convey a work based on the Program, or the modifications to
-produce it from the Program, in the form of source code under the
-terms of section 4, provided that you also meet all of these conditions:
-
-    a) The work must carry prominent notices stating that you modified
-    it, and giving a relevant date.
-
-    b) The work must carry prominent notices stating that it is
-    released under this License and any conditions added under section
-    7.  This requirement modifies the requirement in section 4 to
-    "keep intact all notices".
-
-    c) You must license the entire work, as a whole, under this
-    License to anyone who comes into possession of a copy.  This
-    License will therefore apply, along with any applicable section 7
-    additional terms, to the whole of the work, and all its parts,
-    regardless of how they are packaged.  This License gives no
-    permission to license the work in any other way, but it does not
-    invalidate such permission if you have separately received it.
-
-    d) If the work has interactive user interfaces, each must display
-    Appropriate Legal Notices; however, if the Program has interactive
-    interfaces that do not display Appropriate Legal Notices, your
-    work need not make them do so.
-
-  A compilation of a covered work with other separate and independent
-works, which are not by their nature extensions of the covered work,
-and which are not combined with it such as to form a larger program,
-in or on a volume of a storage or distribution medium, is called an
-"aggregate" if the compilation and its resulting copyright are not
-used to limit the access or legal rights of the compilation's users
-beyond what the individual works permit.  Inclusion of a covered work
-in an aggregate does not cause this License to apply to the other
-parts of the aggregate.
-
-  6. Conveying Non-Source Forms.
-
-  You may convey a covered work in object code form under the terms
-of sections 4 and 5, provided that you also convey the
-machine-readable Corresponding Source under the terms of this License,
-in one of these ways:
-
-    a) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by the
-    Corresponding Source fixed on a durable physical medium
-    customarily used for software interchange.
-
-    b) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by a
-    written offer, valid for at least three years and valid for as
-    long as you offer spare parts or customer support for that product
-    model, to give anyone who possesses the object code either (1) a
-    copy of the Corresponding Source for all the software in the
-    product that is covered by this License, on a durable physical
-    medium customarily used for software interchange, for a price no
-    more than your reasonable cost of physically performing this
-    conveying of source, or (2) access to copy the
-    Corresponding Source from a network server at no charge.
-
-    c) Convey individual copies of the object code with a copy of the
-    written offer to provide the Corresponding Source.  This
-    alternative is allowed only occasionally and noncommercially, and
-    only if you received the object code with such an offer, in accord
-    with subsection 6b.
-
-    d) Convey the object code by offering access from a designated
-    place (gratis or for a charge), and offer equivalent access to the
-    Corresponding Source in the same way through the same place at no
-    further charge.  You need not require recipients to copy the
-    Corresponding Source along with the object code.  If the place to
-    copy the object code is a network server, the Corresponding Source
-    may be on a different server (operated by you or a third party)
-    that supports equivalent copying facilities, provided you maintain
-    clear directions next to the object code saying where to find the
-    Corresponding Source.  Regardless of what server hosts the
-    Corresponding Source, you remain obligated to ensure that it is
-    available for as long as needed to satisfy these requirements.
-
-    e) Convey the object code using peer-to-peer transmission, provided
-    you inform other peers where the object code and Corresponding
-    Source of the work are being offered to the general public at no
-    charge under subsection 6d.
-
-  A separable portion of the object code, whose source code is excluded
-from the Corresponding Source as a System Library, need not be
-included in conveying the object code work.
-
-  A "User Product" is either (1) a "consumer product", which means any
-tangible personal property which is normally used for personal, family,
-or household purposes, or (2) anything designed or sold for incorporation
-into a dwelling.  In determining whether a product is a consumer product,
-doubtful cases shall be resolved in favor of coverage.  For a particular
-product received by a particular user, "normally used" refers to a
-typical or common use of that class of product, regardless of the status
-of the particular user or of the way in which the particular user
-actually uses, or expects or is expected to use, the product.  A product
-is a consumer product regardless of whether the product has substantial
-commercial, industrial or non-consumer uses, unless such uses represent
-the only significant mode of use of the product.
-
-  "Installation Information" for a User Product means any methods,
-procedures, authorization keys, or other information required to install
-and execute modified versions of a covered work in that User Product from
-a modified version of its Corresponding Source.  The information must
-suffice to ensure that the continued functioning of the modified object
-code is in no case prevented or interfered with solely because
-modification has been made.
-
-  If you convey an object code work under this section in, or with, or
-specifically for use in, a User Product, and the conveying occurs as
-part of a transaction in which the right of possession and use of the
-User Product is transferred to the recipient in perpetuity or for a
-fixed term (regardless of how the transaction is characterized), the
-Corresponding Source conveyed under this section must be accompanied
-by the Installation Information.  But this requirement does not apply
-if neither you nor any third party retains the ability to install
-modified object code on the User Product (for example, the work has
-been installed in ROM).
-
-  The requirement to provide Installation Information does not include a
-requirement to continue to provide support service, warranty, or updates
-for a work that has been modified or installed by the recipient, or for
-the User Product in which it has been modified or installed.  Access to a
-network may be denied when the modification itself materially and
-adversely affects the operation of the network or violates the rules and
-protocols for communication across the network.
-
-  Corresponding Source conveyed, and Installation Information provided,
-in accord with this section must be in a format that is publicly
-documented (and with an implementation available to the public in
-source code form), and must require no special password or key for
-unpacking, reading or copying.
-
-  7. Additional Terms.
-
-  "Additional permissions" are terms that supplement the terms of this
-License by making exceptions from one or more of its conditions.
-Additional permissions that are applicable to the entire Program shall
-be treated as though they were included in this License, to the extent
-that they are valid under applicable law.  If additional permissions
-apply only to part of the Program, that part may be used separately
-under those permissions, but the entire Program remains governed by
-this License without regard to the additional permissions.
-
-  When you convey a copy of a covered work, you may at your option
-remove any additional permissions from that copy, or from any part of
-it.  (Additional permissions may be written to require their own
-removal in certain cases when you modify the work.)  You may place
-additional permissions on material, added by you to a covered work,
-for which you have or can give appropriate copyright permission.
-
-  Notwithstanding any other provision of this License, for material you
-add to a covered work, you may (if authorized by the copyright holders of
-that material) supplement the terms of this License with terms:
-
-    a) Disclaiming warranty or limiting liability differently from the
-    terms of sections 15 and 16 of this License; or
-
-    b) Requiring preservation of specified reasonable legal notices or
-    author attributions in that material or in the Appropriate Legal
-    Notices displayed by works containing it; or
-
-    c) Prohibiting misrepresentation of the origin of that material, or
-    requiring that modified versions of such material be marked in
-    reasonable ways as different from the original version; or
-
-    d) Limiting the use for publicity purposes of names of licensors or
-    authors of the material; or
-
-    e) Declining to grant rights under trademark law for use of some
-    trade names, trademarks, or service marks; or
-
-    f) Requiring indemnification of licensors and authors of that
-    material by anyone who conveys the material (or modified versions of
-    it) with contractual assumptions of liability to the recipient, for
-    any liability that these contractual assumptions directly impose on
-    those licensors and authors.
-
-  All other non-permissive additional terms are considered "further
-restrictions" within the meaning of section 10.  If the Program as you
-received it, or any part of it, contains a notice stating that it is
-governed by this License along with a term that is a further
-restriction, you may remove that term.  If a license document contains
-a further restriction but permits relicensing or conveying under this
-License, you may add to a covered work material governed by the terms
-of that license document, provided that the further restriction does
-not survive such relicensing or conveying.
-
-  If you add terms to a covered work in accord with this section, you
-must place, in the relevant source files, a statement of the
-additional terms that apply to those files, or a notice indicating
-where to find the applicable terms.
-
-  Additional terms, permissive or non-permissive, may be stated in the
-form of a separately written license, or stated as exceptions;
-the above requirements apply either way.
-
-  8. Termination.
-
-  You may not propagate or modify a covered work except as expressly
-provided under this License.  Any attempt otherwise to propagate or
-modify it is void, and will automatically terminate your rights under
-this License (including any patent licenses granted under the third
-paragraph of section 11).
-
-  However, if you cease all violation of this License, then your
-license from a particular copyright holder is reinstated (a)
-provisionally, unless and until the copyright holder explicitly and
-finally terminates your license, and (b) permanently, if the copyright
-holder fails to notify you of the violation by some reasonable means
-prior to 60 days after the cessation.
-
-  Moreover, your license from a particular copyright holder is
-reinstated permanently if the copyright holder notifies you of the
-violation by some reasonable means, this is the first time you have
-received notice of violation of this License (for any work) from that
-copyright holder, and you cure the violation prior to 30 days after
-your receipt of the notice.
-
-  Termination of your rights under this section does not terminate the
-licenses of parties who have received copies or rights from you under
-this License.  If your rights have been terminated and not permanently
-reinstated, you do not qualify to receive new licenses for the same
-material under section 10.
-
-  9. Acceptance Not Required for Having Copies.
-
-  You are not required to accept this License in order to receive or
-run a copy of the Program.  Ancillary propagation of a covered work
-occurring solely as a consequence of using peer-to-peer transmission
-to receive a copy likewise does not require acceptance.  However,
-nothing other than this License grants you permission to propagate or
-modify any covered work.  These actions infringe copyright if you do
-not accept this License.  Therefore, by modifying or propagating a
-covered work, you indicate your acceptance of this License to do so.
-
-  10. Automatic Licensing of Downstream Recipients.
-
-  Each time you convey a covered work, the recipient automatically
-receives a license from the original licensors, to run, modify and
-propagate that work, subject to this License.  You are not responsible
-for enforcing compliance by third parties with this License.
-
-  An "entity transaction" is a transaction transferring control of an
-organization, or substantially all assets of one, or subdividing an
-organization, or merging organizations.  If propagation of a covered
-work results from an entity transaction, each party to that
-transaction who receives a copy of the work also receives whatever
-licenses to the work the party's predecessor in interest had or could
-give under the previous paragraph, plus a right to possession of the
-Corresponding Source of the work from the predecessor in interest, if
-the predecessor has it or can get it with reasonable efforts.
-
-  You may not impose any further restrictions on the exercise of the
-rights granted or affirmed under this License.  For example, you may
-not impose a license fee, royalty, or other charge for exercise of
-rights granted under this License, and you may not initiate litigation
-(including a cross-claim or counterclaim in a lawsuit) alleging that
-any patent claim is infringed by making, using, selling, offering for
-sale, or importing the Program or any portion of it.
-
-  11. Patents.
-
-  A "contributor" is a copyright holder who authorizes use under this
-License of the Program or a work on which the Program is based.  The
-work thus licensed is called the contributor's "contributor version".
-
-  A contributor's "essential patent claims" are all patent claims
-owned or controlled by the contributor, whether already acquired or
-hereafter acquired, that would be infringed by some manner, permitted
-by this License, of making, using, or selling its contributor version,
-but do not include claims that would be infringed only as a
-consequence of further modification of the contributor version.  For
-purposes of this definition, "control" includes the right to grant
-patent sublicenses in a manner consistent with the requirements of
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
 this License.
 
-  Each contributor grants you a non-exclusive, worldwide, royalty-free
-patent license under the contributor's essential patent claims, to
-make, use, sell, offer for sale, import and otherwise run, modify and
-propagate the contents of its contributor version.
-
-  In the following three paragraphs, a "patent license" is any express
-agreement or commitment, however denominated, not to enforce a patent
-(such as an express permission to practice a patent or covenant not to
-sue for patent infringement).  To "grant" such a patent license to a
-party means to make such an agreement or commitment not to enforce a
-patent against the party.
-
-  If you convey a covered work, knowingly relying on a patent license,
-and the Corresponding Source of the work is not available for anyone
-to copy, free of charge and under the terms of this License, through a
-publicly available network server or other readily accessible means,
-then you must either (1) cause the Corresponding Source to be so
-available, or (2) arrange to deprive yourself of the benefit of the
-patent license for this particular work, or (3) arrange, in a manner
-consistent with the requirements of this License, to extend the patent
-license to downstream recipients.  "Knowingly relying" means you have
-actual knowledge that, but for the patent license, your conveying the
-covered work in a country, or your recipient's use of the covered work
-in a country, would infringe one or more identifiable patents in that
-country that you have reason to believe are valid.
-
-  If, pursuant to or in connection with a single transaction or
-arrangement, you convey, or propagate by procuring conveyance of, a
-covered work, and grant a patent license to some of the parties
-receiving the covered work authorizing them to use, propagate, modify
-or convey a specific copy of the covered work, then the patent license
-you grant is automatically extended to all recipients of the covered
-work and works based on it.
-
-  A patent license is "discriminatory" if it does not include within
-the scope of its coverage, prohibits the exercise of, or is
-conditioned on the non-exercise of one or more of the rights that are
-specifically granted under this License.  You may not convey a covered
-work if you are a party to an arrangement with a third party that is
-in the business of distributing software, under which you make payment
-to the third party based on the extent of your activity of conveying
-the work, and under which the third party grants, to any of the
-parties who would receive the covered work from you, a discriminatory
-patent license (a) in connection with copies of the covered work
-conveyed by you (or copies made from those copies), or (b) primarily
-for and in connection with specific products or compilations that
-contain the covered work, unless you entered into that arrangement,
-or that patent license was granted, prior to 28 March 2007.
-
-  Nothing in this License shall be construed as excluding or limiting
-any implied license or other defenses to infringement that may
-otherwise be available to you under applicable patent law.
-
-  12. No Surrender of Others' Freedom.
-
-  If conditions are imposed on you (whether by court order, agreement or
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot convey a
-covered work so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you may
-not convey it at all.  For example, if you agree to terms that obligate you
-to collect a royalty for further conveying from those to whom you convey
-the Program, the only way you could satisfy both those terms and this
-License would be to refrain entirely from conveying the Program.
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
 
-  13. Use with the GNU Affero General Public License.
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
 
-  Notwithstanding any other provision of this License, you have
-permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a single
-combined work, and to convey the resulting work.  The terms of this
-License will continue to apply to the part which is the covered work,
-but the special requirements of the GNU Affero General Public License,
-section 13, concerning interaction through a network will apply to the
-combination as such.
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
 
-  14. Revised Versions of this License.
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
 
-  The Free Software Foundation may publish revised and/or new versions of
-the GNU General Public License from time to time.  Such new versions will
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
 be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
-  Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU General
-Public License "or any later version" applies to it, you have the
-option of following the terms and conditions either of that numbered
-version or of any later version published by the Free Software
-Foundation.  If the Program does not specify a version number of the
-GNU General Public License, you may choose any version ever published
-by the Free Software Foundation.
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
 
-  If the Program specifies that a proxy can decide which future
-versions of the GNU General Public License can be used, that proxy's
-public statement of acceptance of a version permanently authorizes you
-to choose that version for the Program.
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
 
-  Later license versions may give you additional or different
-permissions.  However, no additional obligations are imposed on any
-author or copyright holder as a result of your choosing to follow a
-later version.
+                            NO WARRANTY
 
-  15. Disclaimer of Warranty.
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
 
-  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
-APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
-OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
-IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
-ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-
-  16. Limitation of Liability.
-
-  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
-THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
-GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
-USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
-DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
-PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
-EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGES.
-
-  17. Interpretation of Sections 15 and 16.
-
-  If the disclaimer of warranty and limitation of liability provided
-above cannot be given local legal effect according to their terms,
-reviewing courts shall apply local law that most closely approximates
-an absolute waiver of all civil liability in connection with the
-Program, unless a warranty or assumption of liability accompanies a
-copy of the Program in return for a fee.
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
 
                      END OF TERMS AND CONDITIONS
 
@@ -628,15 +287,15 @@ free software which everyone can redistribute and change under these terms.
 
   To do so, attach the following notices to the program.  It is safest
 to attach them to the start of each source file to most effectively
-state the exclusion of warranty; and each file should have at least
+convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    {one line to give the program's name and a brief idea of what it does.}
-    Copyright (C) {year}  {name of author}
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
-    This program is free software: you can redistribute it and/or modify
+    This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
+    the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
@@ -644,31 +303,36 @@ the "copyright" line and a pointer to where the full notice is found.
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-  If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
 
-    Sparkling  Copyright (C) 2014 - 2016
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
 
 The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an "about box".
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
 
-  You should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
 
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/changelog.txt
+++ b/changelog.txt
@@ -84,3 +84,338 @@ Housekeeping
 
 ### 2.4.11
 * Tested up to WordPress 6.8.
+
+### 3.0 (never released)
+These notes were labelled 3.0 in readme.md but no 3.0 was ever published;
+WordPress.org went 2.4.9 -> 2.4.10 -> 2.4.11. Preserved verbatim.
+
+- Added PHP 8 support
+- Merge WpChill fork
+- Fixed some bugs
+
+### 2.4.8
+
+- Compatibility with jQuery 3.0
+
+### 2.4.6
+
+- Improved accesibility with keyboard navigation
+
+### 2.4.5
+
+- Added 2 more recommended plugins
+
+### 2.4.4
+
+- Removed subject tags, can't keep more than 3 as per w.org rules
+
+### 2.4.3
+
+- Fixed a few more bugs with FA5 & missing icons
+
+### 2.4.1
+
+- Fixed a bug with FontAwesome 5 & RSS feed icon
+
+### 2.4.0
+
+- Added Colorlib Login Customizer as recommended plugin
+- Updated FontAwesome to v5.1.1
+- Updated FlexSlider to 2.7.0
+- Added Academicons ( https://jpswalsh.github.io/academicons/ )
+- Removed Modernizr.js from distribution
+- Full changelog can be seen here: https://github.com/puikinsh/Sparkling/milestone/1?closed=1
+
+### 2.3.4
+
+- Updated font awesome
+- Fixed custom menu styling in the footer
+- Improved widgets' styling
+- Fixed Sparkling popular posts widget clear bug
+- Fixed custom color for the footer text
+- Added defaults for color controls in Customizer
+- Fixed custom typography bug
+- Improved custom colors
+- Fixed the menu on mobile devices
+- Added a 'read more' button when the read more tag is used
+- Added Epsilon Framework
+- Added Welcome Screen
+
+### 2.3.3 - 09.06.2017
+
+- Improved Dutch translation by Thom de Jonge
+
+### 2.3.2 - 11.10.2016
+
+- Removed redundant functions and replaced with ones from WP core.
+
+### 2.3.1 - 08.07.2016
+
+- Hungarian translation thanks to Varga Szabolcs
+
+### 2.3.0 - 30.06.2016
+
+- Added TGMPA & Kiwi Social Share Plugin
+- Updated theme tags
+- Fixed deprecated constructor notice for widgets
+- Updated language files thanks to Vaidas Elksnys
+- Other fixes and improvements.
+
+### 2.2.3 - 18.03.2016
+
+- Fixed problem when top menu items set to open on new tab.
+- Fixed problems with font reset
+- Fixed problem with one extra post for recent post widget
+- Added missing border for posts when no featured image is used.
+- Added new social media icons.
+
+### 2.2.2 - 18.01.2016
+
+- Updated Spanish translation
+- Fixed problems with excerpts
+- Fixed dribbble icon
+- Updated FontAwesome icons
+
+### 2.2.1 - 11.12.2015
+
+- Fixed error with WooCommerce
+
+### 2.2.0 - 09.12.2015
+
+- Added WooCommerce support
+- Removed legacy code
+- Improved layout manager
+- Added options for sticky/fixed navigation.
+
+### 2.1.1 - 17.11.2015
+
+- Removed redundant function
+
+### 2.1.0 - 27.10.2015
+
+- Added WP-PageNavi support
+- Fixed option for comment section on static pages
+- Fixed problem with French translation
+
+### 2.0.1 - 27.10.2015
+
+- Added callback function for old Social Icons.
+- Removed wp_title callback
+- Updated Font Awesome icon library
+- Simplified social icons
+- Added support for "mailto". Email icon.
+
+### 2.0 - 16.10.2015
+
+- Removed Options Frameowrk in favor to WordPress Theme Customizer. Be careful with this update as it might break things.
+- Added layout selecotr for individual posts/pages.
+- Other code cleanups and improvements.
+
+### 1.9.4 - 29.07.2015
+
+- Added Estonian translation thanks to Kristjan Variksoo
+
+### 1.9.3 - 14.07.2015
+
+- Improved menu color customization options
+- Prepared theme for WordPress 4.3 update.
+
+### 1.9.2 - 15.06.2015
+
+- Fixed minor bug with attachment pages.
+- Fixed minor bug with navigation submenu color on mobile devices.
+- Other menu styling improvements
+- Added Simplified Chinese thanks to KagurazakaKotori
+
+### 1.9.1 - 05.06.2015
+
+- Fixed two minor bugs in custom theme widgets
+
+### 1.9.0 - 21.05.2015
+
+- Introduced option to change full content vs excerpt for blog page.
+- New option to disable comments on static pages via Customizer
+- Removed redundant search form override
+- Added Spotify icon
+- Updated FontAwesome library to 4.3
+- Added Indonesian translation
+
+### 1.8.5 - 21.05.2015
+
+- Properly escaped all translation strings
+- Updated translation files
+
+### 1.8.3 - 04.05.2015
+
+- Added Czech translation
+- Added Ukrainian translation thanks to Vladyslav
+- Added Traditional Chinese thanks to ShuChun
+
+### 1.8.2 - 23.04.2015
+
+- Fixed overlapping CSS selectors when using tag called "navigation".
+- Improved coding for author box below post content
+- Author box is now visible only if there is a author bio/description to show.
+
+### 1.8.1 - 16.04.2015
+
+- Removed accidentally added string from header.php
+
+### 1.8.0 - 04.04.2015
+
+- Updated Options Framework
+- Improved theme translation support
+- Added support for WPML multilingual plugin
+- Other code tweaks and cleanups
+- Added Lithuanian translation
+
+### 1.7.12 - 23.03.2015
+
+- Updated Bootstrap framework to 3.3.4
+- Fixed comment layout on mobile when multiple levels of comments are present
+
+### 1.7.11 - 20.03.2015
+
+- Added Japanese translation
+
+### 1.7.10 - 16.03.2015
+
+- Added Bulgarian translation thanks to @pbosakov
+
+### 1.7.9 - 02.03.2015
+
+- Added Turkish translation thanks to Ender İskender
+
+### 1.7.8 - 11.02.2015
+
+- Improved favicon functionality. Now loaded in WordPress dashboard and frontend.
+
+### 1.7.7 - 23.01.2015
+
+- Fixed minor problems with newly introduced title-tag
+
+### 1.7.6 - 23.01.2015
+
+- Theme now uses "title-tag" that was introduced with WordPress 4.1
+- Updated Bootstrap to 3.3.2
+
+### 1.7.5 - 14.01.2015
+
+- Removed front-page.php template. Instead you can use full-width or regular page template on frontpage
+- Small code cleanup
+- Updated Bootstrap classes for full-width template
+- Updated Russian translation
+
+### 1.7.1 - 15.11.2014
+
+- Updated Bootstrap to v3.3.1
+
+### 1.7.0 - 30.10.2014
+
+- Updated Bootstrap to 3.3.0
+- Updated Font Awesome icons to 4.2.0
+
+### 1.6.3 - 29.10.2014
+
+- Improved Child Theme support
+- Addded GitHub Icon
+
+### 1.6.2 - 23.08.2014
+
+- Added Romanian translation thanks to Bogdan Patru
+
+### 1.6.1 - 31.07.2014
+
+- Added Skype URI support for icons
+- Added Persian language thanks to Robert Nicjoo
+- Added Portuguese (Portugal) translation thanks to Vasco Cruz
+
+### 1.6.0 - 16.07.2014
+
+- Added Portuguese translation thanks to Lucas Mandelli
+- Updated Bootstrap to 3.2
+- Added more flexibility to slider functions via functions.min.js file.
+- Fixed problems with IE 10 & 11
+- Updated modernizer
+- Added bbPress support
+- Improved theme responsiveness
+
+### 1.5.1 - 26.06.2014
+
+- Updated German translations
+- Added another German translation with more polite form thanks to Steffen Lober
+
+### 1.5.0 - 26.05.2014
+
+- Improved Child Theme support
+- Recreated Social Icons
+- Added SoundCloud and Vimeo icons
+- Recreated default WordPress gallery support
+- Improved code consistency in extra.php file
+- Several other code improvement for main theme functions
+- Recreated logic behind color in Theme Options. Now these settings provides with more flexibility.
+- Added German translations thanks to Bernd Schray
+
+### 1.4.2 - 24.05.2014
+
+- Fixed problem with mobile navigation
+- Improved customization options for Navigation bar
+- Defined default social icon color.
+
+### 1.4.1 - 19.05.2014
+
+- Added Russian translation thanks to Evgeny Able
+- Improved Child Theme support
+- Updated Dutch translation
+
+### 1.4.0 - 18.05.2014
+
+- Fixed next/previos button placement on mobile devices.
+- Improved full-width page layout.
+- Added Polish translation thanks to jerry1333 (http://www.jerry1333.net/)
+- Added Dutch translation thanks to Niels Hoogenhout (http://nielshoogenhout.nl/)
+- Updated Options Framework to 1.8.0
+- Updated FontAwesome to 4.1
+
+### 1.3.0 - 12.05.2014
+
+- Added foursquare icon in Sparkling social widget and footer.
+- Added Italian translation thanks to Achille D'Aniello
+- Added French translation thanks to Antoine Lorence
+- Updated translations files
+- Updated 404 error page (404.php)
+- Improved WordPress default galleries
+- Added different content width for full-width pages.
+
+### 1.2.1 - 06.05.2014
+
+- Fixed a tiny bug when comments are closed for single posts.
+
+### 1.2.0 - 29.04.2014
+
+- Added Spanish translation thanks to Hugo (http://hartodebuscar.blogspot.com/)
+- Moved some functions from jQuery to PHP to avoid conflicts with plugins and other JavaScript based scripts.
+- Improved main theme JavaScript compatibility with other plugins and scripts.
+- Added Modernizr for better HTML5 and CSS3 support
+
+### 1.1 - 25.04.2014
+
+- Removed all traces from Underscore template that weren't replaced already. Theme is still based on Underscore but removed some strings to avoid confusion.
+
+### 1.0.4 - 17.04.2014
+
+- Changed Author URI.
+- Added right heading tag for default widgets
+
+### 1.0.1 - 02.04.2014
+
+- Social network urls are now properly escaped using "esc_url"
+- Added licensing information for images in theme screenshot
+- Updated screenshot
+- Improved wp_register_style for Google fonts to be compatible with SSL
+- Removed do_shortcodes from extras.php which falls under plugin territory
+- Fixed missing .js error.
+
+### 1.0 - 01.04.2014
+
+Initial release

--- a/readme.md
+++ b/readme.md
@@ -1,403 +1,161 @@
-# About Theme
+# Sparkling — Free Responsive WordPress Blog & Business Theme
 
-Theme Name: Sparkling<br>
-Theme URI: http://colorlib.com/wp/sparkling/<br>
-Version: 3.0<br>
-Tested up to: WP 5.8.1<br>
-Requires PHP: 5.4.0<br>
-Tested up to: PHP 8.0.10<br>
+[![Version](https://img.shields.io/badge/version-2.6.4-blue.svg)](https://github.com/ColorlibHQ/Sparkling/releases)
+[![WordPress](https://img.shields.io/badge/WordPress-6.0%20–%207.0-21759b.svg)](https://wordpress.org/themes/sparkling/)
+[![PHP](https://img.shields.io/badge/PHP-7.4%20–%208.5-777bb4.svg)](https://www.php.net/)
+[![License](https://img.shields.io/badge/license-GPL--2.0--or--later-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
+[![Downloads](https://img.shields.io/wordpress/theme/dt/sparkling.svg)](https://wordpress.org/themes/sparkling/)
 
-Author: Aigars Silkalns<br>
-Author URI: http://colorlib.com/wp/<br>
-License: GNU General Public License v3.0
-License URI: https://www.gnu.org/licenses/gpl.html
+**Sparkling** is a free, clean, fully responsive **WordPress theme** built on Bootstrap 3, suited to blogs,
+news and magazine sites, business and portfolio sites, and WooCommerce shops. It ships a full-width slider,
+four sidebar layouts, dozens of live Customizer options, and translations in over twenty languages.
 
----
+[**Live demo**](https://colorlibhub.com/sparkling/) · [**Download from WordPress.org**](https://wordpress.org/themes/sparkling/) · [**Documentation**](https://colorlib.com/wp/support/sparkling/) · [**Support forum**](https://colorlib.com/wp/forums/)
 
-Sparkling theme, Copyright 2014-2021 colorlib.com
-Sparkling WordPress theme is distributed under the terms of the GNU GPL
-Sparkling is based on Underscores https://underscores.me/, (C) 2012-2017 Automattic, Inc.
+![Sparkling WordPress theme screenshot](screenshot.png)
 
 ---
 
-# Credits
+## Contents
+
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Features](#features)
+- [Customizer options](#customizer-options)
+- [WooCommerce](#woocommerce)
+- [Translations](#translations)
+- [Child themes](#child-themes)
+- [Development](#development)
+- [Changelog](#changelog)
+- [Credits and licensing](#credits-and-licensing)
 
-Unless otherwise specified, all the theme files, scripts and images are licensed under GPLv3 license
+## Requirements
 
-Sparkling theme uses:
+| | |
+|---|---|
+| WordPress | 6.0 or newer (tested to 7.0) |
+| PHP | 7.4 or newer (tested to 8.5) |
+| Browsers | All current evergreen browsers. Internet Explorer is no longer supported. |
 
-- FontAwesome (https://fontawesome.com) licensed under the SIL OFL 1.1 (http://scripts.sil.org/OFL)
-- Bootstrap (https://getbootstrap.com/) licensed under MIT license (https://github.com/twbs/bootstrap/blob/master/LICENSE)
-- WP-Bootstrap-NavWalker licensed under the GPLv2 license (https://www.gnu.org/licenses/gpl-2.0.html)
-- FlexSlider by WooThemes licensed under the GPLv2 license (https://www.gnu.org/licenses/gpl-2.0.html)
-- Unless otherwise specified, all images are created by Colorlib
+## Installation
 
-# Description
+**From your dashboard** — go to **Appearance → Themes → Add New**, search for *Sparkling*, then click
+**Install** and **Activate**.
 
-Sparkling is a clean minimal and responsive WordPress theme well suited for travel, health, business, finance, portfolio, design, art, photography, personal, ecommerce and any other creative websites and blogs. Developed using Bootstrap 3 that makes it mobile and tablets friendly. Theme comes with full-screen slider, social icon integration, author bio, popular posts widget and improved category widget. Sparkling incorporates latest web standards such as HTML5 and CSS3 and is SEO friendly thanks to its clean structure and codebase. It has dozens of Theme Options based on WordPress Customizer to change theme layout, colors, fonts, slider settings and much more. Theme is also translation and multilingual ready, compatible with WPML and is available in Spanish, French, Dutch, Polish, Russian, German, Brazilian Portuguese, Portuguese (Portugal), Persian (Iranian language), Romanian, Turkish, Bulgarian, Japanese, Lithuanian, Czech, Ukrainian, Traditional Chinese, Simplified Chinese, Indonesian, Estonian, Spanish (Argentina) and Italian. Sparkling is a free WordPress theme with premium functionality and design. Theme is ecommerce ready thanks to its WooCommerce integration. Now theme is optimized to work with bbPress, Contact Form 7, Jetpack, WooCommerce and other popular free and premium plugins. Lately we introduced a sticky/fixed navigation that you can enable or disable via WordPress Customizer.
+**From a zip** — download the latest release, then **Appearance → Themes → Add New → Upload Theme**,
+choose the zip and click **Install Now**.
 
-For questions, comments or bug reports, visit Colorlib support forum (http://colorlib.com/wp/forums).
+**Manually** — unzip into `wp-content/themes/` so the theme lives at `wp-content/themes/sparkling/`,
+then activate it under **Appearance → Themes**.
 
-# Installation
+After activating, open **Appearance → Customize** to configure the theme, or **Appearance → About Sparkling**
+for a guided setup.
 
-You can install the theme through the WordPress installer under "Themes" > "Install themes" by searching for "Sparkling".
+## Features
 
-Alternatively you can download the file, unzip it and move the unzipped contents to the "wp-content/themes" folder of your WordPress installation. You will then be able to activate the theme.
+- **Fully responsive** Bootstrap 3.4.1 layout, mobile and tablet friendly
+- **Front page slider** — full width, pulls from any category, with captions and touch support
+- **Four sidebar layouts** — right, left, none, or full width, set globally or per post, page and product
+- **Live Customizer options** for colours, typography, header, footer and layout
+- **Call-to-action bar** on the front page
+- **Custom widgets** — social icons, popular posts, and an enhanced categories widget
+- **Post formats** — aside, image, video, quote and link
+- **Sticky navigation**, optional
+- **Author bio box**, threaded comments and Gravatar support
+- **Translation ready**, WPML compatible, with 20+ bundled translations
+- **WooCommerce ready**
+- **No jQuery dependency** in the theme's own JavaScript
+- **Block editor support** — responsive embeds, block styles, wide blocks and an editor stylesheet
+- **Accessibility touches** — skip link, visible keyboard focus, `prefers-reduced-motion` support
 
-Afterwards you can continue theme setup and customization via WordPress Dashboard - Appearance - Theme Options. For detailed theme documentation, please visit http://colorlib.com/wp/support/sparkling
+## Customizer options
 
-# Theme Features
+All settings live under **Appearance → Customize → Sparkling Options**:
 
-- Bootstrap 3 integration
-- Responsive design
-- Unlimited color variations
-- SEO friendly
-- WordPress Theme Customizer support
-- Image centric approach
-- Internationalized & localization
-- Drop-down Menu
-- Cross-browser compatibility
-- Threaded Comments
-- Gravatar ready
-- Featured slider
-- Font Awesome icons
-- WooCommerce support
+| Section | What it controls |
+|---|---|
+| Content | Post excerpts, comments on static pages |
+| Slider | On/off, source category, number of slides, slide links |
+| Layout | Sidebar position, element colours, WooCommerce page layout |
+| Call to action | Text, button label, link, colours |
+| Typography | Body font family, size, weight and colour |
+| Header | Background, link and hover colours, sticky navigation |
+| Footer | Background, text and link colours, social icons, custom footer text |
+| Social | Social icon menu, Academicons for academic profiles |
+| Archive | Custom titles for tag, category, author and date archives |
 
-# Documentation
+## WooCommerce
 
-Theme documentation is available on http://colorlib.com/wp/support/sparkling
+Sparkling supports WooCommerce out of the box — shop, product, cart, checkout and account pages all
+inherit the theme's styling, and product galleries get zoom, lightbox and slider support.
 
-# Changelog
+WooCommerce pages have their own layout setting under **Layout Options**, and individual products can
+override it from the layout box in the editor sidebar.
 
-## 3.0
+The theme overrides no WooCommerce templates, so it stays compatible as WooCommerce updates.
 
-- Added PHP 8 support
-- Merge WpChill fork
-- Fixed some bugs
+## Translations
 
-## 2.4.8
+Sparkling ships `.po`/`.mo` catalogues for 20+ locales in [`languages/`](languages/), plus an up-to-date
+`sparkling.pot` for new translations.
 
-- Compatibility with jQuery 3.0
+Translations are also managed on
+[translate.wordpress.org](https://translate.wordpress.org/projects/wp-themes/sparkling/), and language
+packs from there take precedence over the bundled files.
 
-## 2.4.6
+## Child themes
 
-- Improved accesibility with keyboard navigation
+Sparkling is built to be extended. Template functions are wrapped in `function_exists()` so a child theme
+can redefine them, and the theme exposes filters such as `sparkling_allow_google_fonts` and
+`sparkling_custom_background_args`.
 
-## 2.4.5
+If you override template files in a child theme, note that the wrapper markup is split across three files:
+`header.php` opens the page containers, `sidebar.php` closes `.main-content-inner` before emitting
+`#secondary`, and `footer.php` closes the rest. A template that skips `get_sidebar()` must close
+`.main-content-inner` itself — see `page-fullwidth.php`.
 
-- Added 2 more recommended plugins
+## Development
 
-## 2.4.4
+The theme ships ready to run; there is no build step required to use it.
 
-- Removed subject tags, can't keep more than 3 as per w.org rules
+```bash
+git clone https://github.com/ColorlibHQ/Sparkling.git
+# symlink or copy into wp-content/themes/sparkling
+```
 
-## 2.4.3
+`style.css` and the files in `assets/css/` are edited directly. Minified assets are committed alongside
+their sources and must be regenerated by hand when the source changes:
 
-- Fixed a few more bugs with FA5 & missing icons
+```bash
+npx terser assets/js/widget.js -c -m -o assets/js/widget.min.js
+```
 
-## 2.4.1
+Bug reports and pull requests are welcome on the [issue tracker](https://github.com/ColorlibHQ/Sparkling/issues).
 
-- Fixed a bug with FontAwesome 5 & RSS feed icon
+## Changelog
 
-## 2.4.0
+The full version history, from 1.0 in April 2014 to the current release, is in
+[`changelog.txt`](changelog.txt). It is also rendered in the WordPress dashboard under
+**Appearance → About Sparkling → Changelog**.
 
-- Added Colorlib Login Customizer as recommended plugin
-- Updated FontAwesome to v5.1.1
-- Updated FlexSlider to 2.7.0
-- Added Academicons ( https://jpswalsh.github.io/academicons/ )
-- Removed Modernizr.js from distribution
-- Full changelog can be seen here: https://github.com/puikinsh/Sparkling/milestone/1?closed=1
+## Credits and licensing
 
-## 2.3.4
+Sparkling, Copyright 2014–2026 [Colorlib](https://colorlib.com/).
+Distributed under the **GNU General Public License v2 or later** —
+see [gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html).
 
-- Updated font awesome
-- Fixed custom menu styling in the footer
-- Improved widgets' styling
-- Fixed Sparkling popular posts widget clear bug
-- Fixed custom color for the footer text
-- Added defaults for color controls in Customizer
-- Fixed custom typography bug
-- Improved custom colors
-- Fixed the menu on mobile devices
-- Added a 'read more' button when the read more tag is used
-- Added Epsilon Framework
-- Added Welcome Screen
+Sparkling is based on [Underscores](https://underscores.me/), (C) 2012–2015 Automattic, Inc.,
+licensed GPLv2 or later.
 
-## 2.3.3 - 09.06.2017
+Bundled third-party resources:
 
-- Improved Dutch translation by Thom de Jonge
+| Resource | Version | License |
+|---|---|---|
+| [Bootstrap](https://getbootstrap.com/) | 3.4.1 | MIT |
+| [FlexSlider](https://github.com/woocommerce/FlexSlider) | 2.7.0 | GPLv2 |
+| [Font Awesome Free](https://fontawesome.com/license) | 5.1.1 | Icons CC BY 4.0, Fonts SIL OFL 1.1, Code MIT |
+| [Academicons](https://jpswalsh.github.io/academicons/) | 1.8.6 | Fonts SIL OFL 1.1, Code MIT |
+| [WP Bootstrap Navwalker](https://github.com/wp-bootstrap/wp-bootstrap-navwalker) | — | GPLv2 or later |
 
-## 2.3.2 - 11.10.2016
-
-- Removed redundant functions and replaced with ones from WP core.
-
-## 2.3.1 - 08.07.2016
-
-- Hungarian translation thanks to Varga Szabolcs
-
-## 2.3.0 - 30.06.2016
-
-- Added TGMPA & Kiwi Social Share Plugin
-- Updated theme tags
-- Fixed deprecated constructor notice for widgets
-- Updated language files thanks to Vaidas Elksnys
-- Other fixes and improvements.
-
-## 2.2.3 - 18.03.2016
-
-- Fixed problem when top menu items set to open on new tab.
-- Fixed problems with font reset
-- Fixed problem with one extra post for recent post widget
-- Added missing border for posts when no featured image is used.
-- Added new social media icons.
-
-## 2.2.2 - 18.01.2016
-
-- Updated Spanish translation
-- Fixed problems with excerpts
-- Fixed dribbble icon
-- Updated FontAwesome icons
-
-## 2.2.1 - 11.12.2015
-
-- Fixed error with WooCommerce
-
-## 2.2.0 - 09.12.2015
-
-- Added WooCommerce support
-- Removed legacy code
-- Improved layout manager
-- Added options for sticky/fixed navigation.
-
-## 2.1.1 - 17.11.2015
-
-- Removed redundant function
-
-## 2.1.0 - 27.10.2015
-
-- Added WP-PageNavi support
-- Fixed option for comment section on static pages
-- Fixed problem with French translation
-
-## 2.0.1 - 27.10.2015
-
-- Added callback function for old Social Icons.
-- Removed wp_title callback
-- Updated Font Awesome icon library
-- Simplified social icons
-- Added support for "mailto". Email icon.
-
-## 2.0 - 16.10.2015
-
-- Removed Options Frameowrk in favor to WordPress Theme Customizer. Be careful with this update as it might break things.
-- Added layout selecotr for individual posts/pages.
-- Other code cleanups and improvements.
-
-## 1.9.4 - 29.07.2015
-
-- Added Estonian translation thanks to Kristjan Variksoo
-
-## 1.9.3 - 14.07.2015
-
-- Improved menu color customization options
-- Prepared theme for WordPress 4.3 update.
-
-## 1.9.2 - 15.06.2015
-
-- Fixed minor bug with attachment pages.
-- Fixed minor bug with navigation submenu color on mobile devices.
-- Other menu styling improvements
-- Added Simplified Chinese thanks to KagurazakaKotori
-
-## 1.9.1 - 05.06.2015
-
-- Fixed two minor bugs in custom theme widgets
-
-## 1.9.0 - 21.05.2015
-
-- Introduced option to change full content vs excerpt for blog page.
-- New option to disable comments on static pages via Customizer
-- Removed redundant search form override
-- Added Spotify icon
-- Updated FontAwesome library to 4.3
-- Added Indonesian translation
-
-## 1.8.5 - 21.05.2015
-
-- Properly escaped all translation strings
-- Updated translation files
-
-## 1.8.3 - 04.05.2015
-
-- Added Czech translation
-- Added Ukrainian translation thanks to Vladyslav
-- Added Traditional Chinese thanks to ShuChun
-
-## 1.8.2 - 23.04.2015
-
-- Fixed overlapping CSS selectors when using tag called "navigation".
-- Improved coding for author box below post content
-- Author box is now visible only if there is a author bio/description to show.
-
-## 1.8.1 - 16.04.2015
-
-- Removed accidentally added string from header.php
-
-## 1.8.0 - 04.04.2015
-
-- Updated Options Framework
-- Improved theme translation support
-- Added support for WPML multilingual plugin
-- Other code tweaks and cleanups
-- Added Lithuanian translation
-
-## 1.7.12 - 23.03.2015
-
-- Updated Bootstrap framework to 3.3.4
-- Fixed comment layout on mobile when multiple levels of comments are present
-
-## 1.7.11 - 20.03.2015
-
-- Added Japanese translation
-
-## 1.7.10 - 16.03.2015
-
-- Added Bulgarian translation thanks to @pbosakov
-
-## 1.7.9 - 02.03.2015
-
-- Added Turkish translation thanks to Ender İskender
-
-## 1.7.8 - 11.02.2015
-
-- Improved favicon functionality. Now loaded in WordPress dashboard and frontend.
-
-## 1.7.7 - 23.01.2015
-
-- Fixed minor problems with newly introduced title-tag
-
-## 1.7.6 - 23.01.2015
-
-- Theme now uses "title-tag" that was introduced with WordPress 4.1
-- Updated Bootstrap to 3.3.2
-
-## 1.7.5 - 14.01.2015
-
-- Removed front-page.php template. Instead you can use full-width or regular page template on frontpage
-- Small code cleanup
-- Updated Bootstrap classes for full-width template
-- Updated Russian translation
-
-## 1.7.1 - 15.11.2014
-
-- Updated Bootstrap to v3.3.1
-
-## 1.7.0 - 30.10.2014
-
-- Updated Bootstrap to 3.3.0
-- Updated Font Awesome icons to 4.2.0
-
-## 1.6.3 - 29.10.2014
-
-- Improved Child Theme support
-- Addded GitHub Icon
-
-## 1.6.2 - 23.08.2014
-
-- Added Romanian translation thanks to Bogdan Patru
-
-## 1.6.1 - 31.07.2014
-
-- Added Skype URI support for icons
-- Added Persian language thanks to Robert Nicjoo
-- Added Portuguese (Portugal) translation thanks to Vasco Cruz
-
-## 1.6.0 - 16.07.2014
-
-- Added Portuguese translation thanks to Lucas Mandelli
-- Updated Bootstrap to 3.2
-- Added more flexibility to slider functions via functions.min.js file.
-- Fixed problems with IE 10 & 11
-- Updated modernizer
-- Added bbPress support
-- Improved theme responsiveness
-
-## 1.5.1 - 26.06.2014
-
-- Updated German translations
-- Added another German translation with more polite form thanks to Steffen Lober
-
-## 1.5.0 - 26.05.2014
-
-- Improved Child Theme support
-- Recreated Social Icons
-- Added SoundCloud and Vimeo icons
-- Recreated default WordPress gallery support
-- Improved code consistency in extra.php file
-- Several other code improvement for main theme functions
-- Recreated logic behind color in Theme Options. Now these settings provides with more flexibility.
-- Added German translations thanks to Bernd Schray
-
-## 1.4.2 - 24.05.2014
-
-- Fixed problem with mobile navigation
-- Improved customization options for Navigation bar
-- Defined default social icon color.
-
-## 1.4.1 - 19.05.2014
-
-- Added Russian translation thanks to Evgeny Able
-- Improved Child Theme support
-- Updated Dutch translation
-
-## 1.4.0 - 18.05.2014
-
-- Fixed next/previos button placement on mobile devices.
-- Improved full-width page layout.
-- Added Polish translation thanks to jerry1333 (http://www.jerry1333.net/)
-- Added Dutch translation thanks to Niels Hoogenhout (http://nielshoogenhout.nl/)
-- Updated Options Framework to 1.8.0
-- Updated FontAwesome to 4.1
-
-## 1.3.0 - 12.05.2014
-
-- Added foursquare icon in Sparkling social widget and footer.
-- Added Italian translation thanks to Achille D'Aniello
-- Added French translation thanks to Antoine Lorence
-- Updated translations files
-- Updated 404 error page (404.php)
-- Improved WordPress default galleries
-- Added different content width for full-width pages.
-
-## 1.2.1 - 06.05.2014
-
-- Fixed a tiny bug when comments are closed for single posts.
-
-## 1.2.0 - 29.04.2014
-
-- Added Spanish translation thanks to Hugo (http://hartodebuscar.blogspot.com/)
-- Moved some functions from jQuery to PHP to avoid conflicts with plugins and other JavaScript based scripts.
-- Improved main theme JavaScript compatibility with other plugins and scripts.
-- Added Modernizr for better HTML5 and CSS3 support
-
-## 1.1 - 25.04.2014
-
-- Removed all traces from Underscore template that weren't replaced already. Theme is still based on Underscore but removed some strings to avoid confusion.
-
-## 1.0.4 - 17.04.2014
-
-- Changed Author URI.
-- Added right heading tag for default widgets
-
-## 1.0.1 - 02.04.2014
-
-- Social network urls are now properly escaped using "esc_url"
-- Added licensing information for images in theme screenshot
-- Updated screenshot
-- Improved wp_register_style for Google fonts to be compatible with SSL
-- Removed do_shortcodes from extras.php which falls under plugin territory
-- Fixed missing .js error.
-
-## 1.0 - 01.04.2014
-
-Initial release
+Unless otherwise noted, all images are created by Colorlib and distributed under the same license
+as the theme.


### PR DESCRIPTION
Re-lands the docs work from #275, which merged into `fix/267-responsive-breakpoints` **after** that branch had already gone to master — so it never reached master. Adds the licence fix on top.

## readme.md — 403 lines → 161

Stale on nearly every fact: version `3.0` (never released), `Tested up to WP 5.8.1`, `Requires PHP 5.4.0`, 2014-2021 copyright, `http://` links, a repo URL that moved to ColorlibHQ, Font Awesome credited as OFL alone (it's Icons CC BY 4.0 / Fonts OFL 1.1 / Code MIT), and Academicons missing entirely.

Rewritten around requirements, three install routes, features, a Customizer options table, WooCommerce, translations, child-theme notes and development setup. Badges and a table of contents. All 22 links verified reachable.

## changelog.txt — one source of truth

Absorbs the 57 historical entries that were buried in `readme.md`. **`+335 / −0`** — nothing dropped; now covers all **64 versions back to 1.0 (April 2014)**, and it's what renders under **Appearance → About Sparkling → Changelog**. The `3.0` entry is preserved verbatim with a note that no 3.0 ever shipped.

## LICENCE.md — GPLv3 text → GPLv2

`LICENCE.md` carried the **GPL version 3** text while `style.css`, `readme.txt` and `readme.md` all declare **v2 or later**. GitHub read the file and publicly labelled this repo **GPL-3.0**, contradicting what WordPress and WordPress.org read from `style.css`.

Replaced with the canonical GPLv2 text from gnu.org, verified against WordPress core's own copy — terms byte-identical, only the trailing 'how to apply' appendix differs.

**No licensing change.** `v2 or later` already permitted v3; the file now names the version the headers do, matching core's pattern (`license.txt` is GPLv2, headers say v2-or-later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)